### PR TITLE
Add Next.js subscription scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/my-subscription-app/.env.example
+++ b/my-subscription-app/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for My Subscription App
+# NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/my-subscription-app/README.md
+++ b/my-subscription-app/README.md
@@ -1,0 +1,14 @@
+# My Subscription App
+
+This is a config-driven subscription platform built with Next.js 13 and TypeScript.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/my-subscription-app/app/page.tsx
+++ b/my-subscription-app/app/page.tsx
@@ -1,0 +1,6 @@
+// Entry page component
+// TODO: Implement the home page of the subscription platform
+
+export default function Page() {
+  return null;
+}

--- a/my-subscription-app/components/ProductForm.tsx
+++ b/my-subscription-app/components/ProductForm.tsx
@@ -1,0 +1,6 @@
+// Form to add or edit subscription products
+// TODO: Implement product form component
+
+export default function ProductForm() {
+  return null;
+}

--- a/my-subscription-app/config/index.ts
+++ b/my-subscription-app/config/index.ts
@@ -1,0 +1,4 @@
+// Configuration utilities for the platform
+// TODO: Load environment variables and other config options here
+
+export default {};

--- a/my-subscription-app/hooks/useSubscription.ts
+++ b/my-subscription-app/hooks/useSubscription.ts
@@ -1,0 +1,6 @@
+// React hook for subscription logic
+// TODO: Implement subscription state management
+
+export default function useSubscription() {
+  return {};
+}

--- a/my-subscription-app/package.json
+++ b/my-subscription-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "my-subscription-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.x",
+    "react": "18.x",
+    "react-dom": "18.x",
+    "tailwindcss": "^3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/my-subscription-app/public/assets/.gitkeep
+++ b/my-subscription-app/public/assets/.gitkeep
@@ -1,0 +1,1 @@
+# asset files

--- a/my-subscription-app/services/subscriptionService.ts
+++ b/my-subscription-app/services/subscriptionService.ts
@@ -1,0 +1,4 @@
+// Service for communicating with the subscription backend
+// TODO: Implement API calls for subscription features
+
+export default {};

--- a/my-subscription-app/styles/global.css
+++ b/my-subscription-app/styles/global.css
@@ -1,0 +1,2 @@
+/* Global styles for the subscription platform */
+/* TODO: Add Tailwind directives and custom styles */

--- a/my-subscription-app/tailwind.config.js
+++ b/my-subscription-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/my-subscription-app/types/index.d.ts
+++ b/my-subscription-app/types/index.d.ts
@@ -1,0 +1,2 @@
+// Shared TypeScript types for the subscription platform
+// TODO: Add interfaces and types here


### PR DESCRIPTION
## Summary
- set up new Next.js 13 scaffold in `my-subscription-app`
- add stub folders and files for config-driven subscription platform
- document how to run the app in README
- track node_modules in .gitignore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688779a87e208327bfa13352ab1ebbbe