### PR TITLE
Add Next.js subscription scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/customize-self-reg-app/.env.example
+++ b/customize-self-reg-app/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables for Customize Self Reg App
+# NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/customize-self-reg-app/README.md
+++ b/customize-self-reg-app/README.md
@@ -1,0 +1,14 @@
+# Customize Self Reg App
+
+This is a config-driven subscription platform built with Next.js 13 and TypeScript.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/customize-self-reg-app/app/page.tsx
+++ b/customize-self-reg-app/app/page.tsx
@@ -1,0 +1,6 @@
+// Entry page component
+// TODO: Implement the home page of the subscription platform
+
+export default function Page() {
+  return null;
+}

--- a/customize-self-reg-app/components/ProductForm.tsx
+++ b/customize-self-reg-app/components/ProductForm.tsx
@@ -1,0 +1,6 @@
+// Form to add or edit subscription products
+// TODO: Implement product form component
+
+export default function ProductForm() {
+  return null;
+}

--- a/customize-self-reg-app/config/index.ts
+++ b/customize-self-reg-app/config/index.ts
@@ -1,0 +1,4 @@
+// Configuration utilities for the platform
+// TODO: Load environment variables and other config options here
+
+export default {};

--- a/customize-self-reg-app/hooks/useSubscription.ts
+++ b/customize-self-reg-app/hooks/useSubscription.ts
@@ -1,0 +1,6 @@
+// React hook for subscription logic
+// TODO: Implement subscription state management
+
+export default function useSubscription() {
+  return {};
+}

--- a/customize-self-reg-app/package.json
+++ b/customize-self-reg-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "customize-self-reg-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.x",
+    "react": "18.x",
+    "react-dom": "18.x",
+    "tailwindcss": "^3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/customize-self-reg-app/public/assets/.gitkeep
+++ b/customize-self-reg-app/public/assets/.gitkeep
@@ -1,0 +1,1 @@
+# asset files

--- a/customize-self-reg-app/services/subscriptionService.ts
+++ b/customize-self-reg-app/services/subscriptionService.ts
@@ -1,0 +1,4 @@
+// Service for communicating with the subscription backend
+// TODO: Implement API calls for subscription features
+
+export default {};

--- a/customize-self-reg-app/styles/global.css
+++ b/customize-self-reg-app/styles/global.css
@@ -1,0 +1,2 @@
+/* Global styles for the subscription platform */
+/* TODO: Add Tailwind directives and custom styles */

--- a/customize-self-reg-app/tailwind.config.js
+++ b/customize-self-reg-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/customize-self-reg-app/types/index.d.ts
+++ b/customize-self-reg-app/types/index.d.ts
@@ -1,0 +1,2 @@
+// Shared TypeScript types for the subscription platform
+// TODO: Add interfaces and types here


### PR DESCRIPTION
## Summary
- set up new Next.js 13 scaffold in `customize-self-reg-app`
- add stub folders and files for config-driven subscription platform
- document how to run the app in README
- track node_modules in .gitignore
- rename scaffold from `my-subscription-app` to `customize-self-reg-app`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688779a87e208327bfa13352ab1ebbbe